### PR TITLE
Display status badge + test node stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ sudo: false
 language: node_js
 node_js:
   - '4'
+  - 'node'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/ekristen/prometheus-client.svg?branch=master)](https://travis-ci.org/ekristen/prometheus-client)
 **STATUS: WIP -- Mostly implemented minus the summary metric**
 
 # Prometheus Client (Pure Javascript)


### PR DESCRIPTION
Two updates here:
1. Display the travis badge. So it is easy to realize if master branch passes test
2. Add `node` as a target for travis at `.travis.yml`. This is a pointer ([see nvm documentaion](https://github.com/creationix/nvm#usage)) to latest node stable. Today this is node 5.7