### PR TITLE
Calculate unique reference to labels without hash

### DIFF
--- a/lib/metric.js
+++ b/lib/metric.js
@@ -1,5 +1,4 @@
 var _ = require('underscore')
-var hash = require('object-hash')
 var xtend = require('xtend')
 
 function BaseMetric (opts) {
@@ -67,7 +66,11 @@ BaseMetric.prototype.values = function BaseMetricValues () {
 }
 
 BaseMetric.prototype.labelHashFor = function labelHashFor (labels) {
-  var lh = hash.sha1(labels)
+  var lh = ''
+  for (var j in labels) {
+    var v = labels[j]
+    lh += j + v
+  }
 
   if (this._labelCache[lh]) {
     return lh
@@ -83,12 +86,17 @@ BaseMetric.prototype.labelHashFor = function labelHashFor (labels) {
     }
   }
 
-  if (this._labelKeys && hash.keys(labels) !== this._labelKeys) {
+  var lkh = ''
+  for (var h in labels) {
+    lkh += h
+  }
+
+  if (this._labelKeys && (lkh !== this._labelKeys)) {
     throw new Error('Labels must have the same signature')
   }
 
   if (!this._labelKeys) {
-    this._labelKeys = hash.keys(labels)
+    this._labelKeys = lkh
   }
 
   this._labelCache[lh] = labels

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "object-hash": "^1.1.2",
     "underscore": "^1.8.3",
     "xtend": "^4.0.0"
   }


### PR DESCRIPTION
Hi, I've been using this module in combination with [my own prometheus-log-client module](https://github.com/JamesBarwell/prometheus-log-client), to produce a metrics endpoint for an application from its existing logs.

We hit a problem during our load tests where our metric exporter was using a huge amount of CPU. I traced the slowdown back to this module, and specifically to the sha1 hash of the labels that is done every time a metric is updated. I tried changing it to use `md5` method available on `object-hash`, but it didn't offer any improvement.

This pull request removes the `object-hash` dependency and uses simple string concatenation to work out a unique reference for the labels. We have seen a significant performance increase using this approach. I don't believe there is any necessity of having such a strong hash function, as all we really care about here is uniqueness.

Under heavy load our application can produce (per instance) in the region of 3-4k metric updates over a 10 second period. We are running these on AWS m2.large instances. Before the change we saw CPU around 50%, and eventual death of the process as it ran out of memory. With this patch, we see CPU hovering around 1% and no trouble keeping up.

Just to be clear, it's only the first use of `sha1` that causes the slowdown. The `keys` method done later isn't a problem due to the caching. But I thought I might as well get rid of the dependency.

Cheers.